### PR TITLE
Hot fix building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,12 +63,15 @@ RUN tar xf /tmp/osmosis.tgz -C /tmp/osmosis
 RUN apt-get update && \
     apt-get install -y libgdal-dev && \
     apt-get clean;
+RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal
+RUN export C_INCLUDE_PATH=/usr/include/gdal
 
 ##################################################
 # Eqasim setup
 ##################################################
 
 COPY requirements.txt /tmp/requirements.txt
+RUN pip install --upgrade pip
 RUN pip install -r /tmp/requirements.txt
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ODTP component for running Eqasim.
 ```odtp new component 
 odtp new odtp-component-entry \
 --name odtp-eqasim \
---component-version 0.4.3 \
+--component-version 0.4.4 \
 --repository https://github.com/odtp-org/odtp-eqasim.git
 ``` 
 
@@ -120,6 +120,10 @@ If you want to kill the session just write `exit`. Also use `tmux ls` to list al
 
 
 ## Changelog
+
+- v0.4.4
+    - Rasterio 1.3.8 included in `requirements.txt` to avoid building errors
+    - odtp-component-client upgrade to v0.1.1
 
 - v0.4.3
     - Ubuntu fixed at 22.04

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ If you want to kill the session just write `exit`. Also use `tmux ls` to list al
 
 - v0.0.1: Version compatible with IDF
 
+## Known errors
+
+- "GPC error": This usually happening when building the image and there is not enough space in the system.
+    ```
+    4.082 W: GPG error: http://archive.ubuntu.com/ubuntu jammy InRelease: At least one invalid signature was encountered.
+4.082 E: The repository 'http://archive.ubuntu.com/ubuntu jammy InRelease' is not signed.
+4.082 W: GPG error: http://archive.ubuntu.com/ubuntu jammy-updates InRelease: At least one invalid signature was encountered.
+4.082 E: The repository 'http://archive.ubuntu.com/ubuntu jammy-updates InRelease' is not signed.
+4.082 W: GPG error: http://archive.ubuntu.com/ubuntu jammy-backports InRelease: At least one invalid signature was encountered.
+4.082 E: The repository 'http://archive.ubuntu.com/ubuntu jammy-backports InRelease' is not signed.
+4.082 W: GPG error: http://security.ubuntu.com/ubuntu jammy-security InRelease: At least one invalid signature was encountered.
+4.082 E: The repository 'http://security.ubuntu.com/ubuntu jammy-security InRelease' is not signed.
+```
+
+
 ## Development. 
 
 Developed by SDSC/CSFM.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ODTP component for running Eqasim.
 ```odtp new component 
 odtp new odtp-component-entry \
 --name odtp-eqasim \
---component-version 0.4.2 \
+--component-version 0.4.3 \
 --repository https://github.com/odtp-org/odtp-eqasim.git
 ``` 
 

--- a/odtp.yml
+++ b/odtp.yml
@@ -1,7 +1,7 @@
 # This file should contain basic component information for your component.
 component-name: odtp-eqasim
 component-author: Carlos Vivar Rios
-component-version: 0.4.2
+component-version: 0.4.3
 component-repository: https://github.com/odtp-org/odtp-eqasim
 component-license: AGPL-3.0
 component-type: ephemeral

--- a/odtp.yml
+++ b/odtp.yml
@@ -1,7 +1,7 @@
 # This file should contain basic component information for your component.
 component-name: odtp-eqasim
 component-author: Carlos Vivar Rios
-component-version: 0.4.3
+component-version: 0.4.4
 component-repository: https://github.com/odtp-org/odtp-eqasim
 component-license: AGPL-3.0
 component-type: ephemeral

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib==3.7.2
+rasterio==1.3.8
 pandas==2.0.3
 scipy==1.11.1
 numpy==1.23.5


### PR DESCRIPTION
- v0.4.4
    - Rasterio 1.3.8 included in `requirements.txt` to avoid building errors
    - odtp-component-client upgrade to v0.1.1